### PR TITLE
add endpoint for selecting an article by id

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -25,7 +25,8 @@ describe('/api', () => {
             .get('/api')
             .expect(200)
             .then(({ body }) => {
-                expect(Object.keys(body.endpoints).length).toBe(2)
+                const endpointsCount = Object.keys(endpoints).length;
+                expect(Object.keys(body.endpoints).length).toBe(endpointsCount)
                 expect(body.endpoints).toEqual(endpoints);
             })
     })
@@ -46,4 +47,45 @@ describe('GET /api/topics', () => {
                 })
             })
     })
+})
+
+describe('GET /api/articles/:article_id', () => {
+    test('sends an array of all topics to the client - status 200', () => {
+        return request(app)
+            .get('/api/articles/1')
+            .expect(200)
+            .then(({body}) => {
+                expect(body.article).toMatchObject({
+                    author: "butter_bridge",
+                    title: "Living in the shadow of a great man",
+                    article_id: 1,
+                    body: "I find this existence challenging",
+                    topic: "mitch",
+                    created_at: "2020-07-09T20:11:00.000Z",
+                    votes: 100,
+                    article_img_url:
+                        "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+                })
+            })
+    })
+
+    test('sends an appropriate status and error message when given a valid but non-existent id - status 404', () => {
+        return request(app)
+          .get('/api/articles/999999')
+          .expect(404)
+          .then((response) => {
+            expect(response.body.msg).toBe('no article found with matching id');
+          });
+      });
+
+      test('sends an appropriate status and error message when given an invalid id', () => {
+        return request(app)
+          .get('/api/articles/not-an-article')
+          .expect(400)
+          .then((response) => {
+            expect(response.body.msg).toBe('Bad request');
+          });
+      });
+
+
 })

--- a/app.js
+++ b/app.js
@@ -2,14 +2,33 @@ const express = require('express')
 const app = express()
 const {getEndpoints} = require('./controllers/endpoints-controllers.js')
 const {getTopics} = require('./controllers/topics-controllers.js')
+const {getArticleById} = require('./controllers/articles-controllers.js')
 
 app.get(`/api`, getEndpoints)
 
 app.get(`/api/topics`, getTopics)
 
+app.get(`/api/articles/:article_id`, getArticleById);
+
 app.all('*', (req, res) => {
     res.status(404).send({ msg: "Route not found" });
 })
+
+app.use((err, req, res, next) => {
+    if(["22P02"].includes(err.code) ) {
+    res.status(400).send({ msg: "Bad request" });
+    } else {
+      next(err)
+    }
+  })
+
+app.use((err, req, res, next) => {
+    if (err.msg) {
+      res.status(err.status).send( { msg: err.msg });
+    } else {
+      next (err);
+    }
+  })
 
 app.use((err, req, res, next) => {
     res.status(500).send({ msg: 'Internal Server Error' })

--- a/controllers/articles-controllers.js
+++ b/controllers/articles-controllers.js
@@ -1,0 +1,16 @@
+const selectArticleById = require('../models/articles-models')
+
+function getArticleById(req, res, next) {
+
+    const { article_id } = req.params;
+
+    selectArticleById(article_id)
+        .then((article) => {
+            res.status(200).send({ article })
+        })
+        .catch((err) => {
+            next(err);
+        })
+}
+
+module.exports = { getArticleById }

--- a/endpoints.json
+++ b/endpoints.json
@@ -8,5 +8,20 @@
     "exampleResponse": {
       "topics": [{ "slug": "football", "description": "Footie!" }]
     }
+  },
+  "GET /api/api/articles/:article_id": {
+    "description": "serves an article object with a given id",
+    "queries": [],
+    "exampleResponse": {
+      "author": "butter_bridge",
+      "title": "Living in the shadow of a great man",
+      "article_id": 1,
+      "body": "I find this existence challenging",
+      "topic": "mitch",
+      "created_at": "2020-07-09T20:11:00.000Z",
+      "votes": 100,
+      "article_img_url":
+          "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+    }
   }
 }

--- a/models/articles-models.js
+++ b/models/articles-models.js
@@ -1,0 +1,14 @@
+const db = require("../db/connection");
+
+function selectArticleById(id) {
+    return db
+    .query('SELECT * FROM articles WHERE article_id = $1', [id])
+    .then(({rows}) => {
+        if(!rows[0]) {
+            return Promise.reject( {status: 404, msg: "no article found with matching id" })
+        }
+        return rows[0];
+    })
+}
+
+module.exports = selectArticleById;


### PR DESCRIPTION
I added an endpoint for selecting an article by its id, along with error handling for both valid and invalid ids. The app is now able to handle both psql and custom errors. 