### PR TITLE
add endpoint for returning all comments for a given article id

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -26,7 +26,6 @@ describe('/api', () => {
             .expect(200)
             .then(({ body }) => {
                 const endpointsCount = Object.keys(endpoints).length;
-                expect(Object.keys(body.endpoints).length).toBe(endpointsCount)
                 expect(body.endpoints).toEqual(endpoints);
             })
     })
@@ -140,4 +139,56 @@ describe('GET /api/articles/:article_id', () => {
                 })
         })
     })
+
+    describe('/api/articles/:article_id/comments', () => {
+        test('sends an array of all comments associated with an article id - status 200', () => {
+            return request(app)
+                .get('/api/articles/1/comments')
+                .expect(200)
+                .then(({ body }) => {
+                    expect(body.comments.length).toBe(11)
+                    body.comments.forEach((comment) => {
+                        expect(comment).toMatchObject({
+                            comment_id: expect.any(Number),
+                            votes: expect.any(Number),
+                            created_at: expect.any(String),
+                            author: expect.any(String),
+                            body: expect.any(String),
+                            article_id: expect.any(Number)
+                        })
+                    })
+                })
+        })
+
+        test('comments sorted by descending order of creation date', () => {
+            return request(app)
+                .get('/api/articles/1/comments')
+                .expect(200)
+                .then(({ body }) => {
+                    expect(body.comments.length).toBe(11)
+                    expect(body.comments).toBeSortedBy('created_at', { descending: true });
+                })
+        })
+    })
+
+    test('responds with error message if article id does not exist', () => {
+        return request(app)
+            .get('/api/articles/999999/comments')
+            .expect(404)
+            .then(({ body }) => {
+                const { msg } = body;
+                expect(msg).toBe("no article found with matching id");
+            })
+    })
+
+    test('responds with empty array if article id has no comments', () => {
+        return request(app)
+            .get('/api/articles/2/comments')
+            .expect(200)
+            .then(({ body }) => {
+                const { comments } = body;
+                expect(comments).toEqual([]);
+            })
+    })
 })
+

--- a/app.js
+++ b/app.js
@@ -2,21 +2,22 @@ const express = require('express')
 const app = express()
 const {getEndpoints} = require('./controllers/endpoints-controllers.js')
 const {getTopics} = require('./controllers/topics-controllers.js')
-const {getArticles, getArticleById} = require('./controllers/articles-controllers.js')
+const {getArticles, getArticleById, getCommentsByArticleId} = require('./controllers/articles-controllers.js')
 
 app.get(`/api`, getEndpoints)
 
 app.get(`/api/topics`, getTopics)
 
 app.get(`/api/articles`, getArticles);
-
 app.get(`/api/articles/:article_id`, getArticleById);
+app.get('/api/articles/:article_id/comments', getCommentsByArticleId)
 
 app.all('*', (req, res) => {
     res.status(404).send({ msg: "Route not found" });
 })
 
 app.use((err, req, res, next) => {
+    // console.log(err);
     if(["22P02"].includes(err.code) ) {
     res.status(400).send({ msg: "Bad request" });
     } else {

--- a/controllers/articles-controllers.js
+++ b/controllers/articles-controllers.js
@@ -1,4 +1,4 @@
-const {selectArticleById, selectArticles} = require('../models/articles-models')
+const { selectArticleById, selectArticles, selectCommentsByArticleId, checkArticleIdExists } = require('../models/articles-models')
 
 function getArticleById(req, res, next) {
 
@@ -24,4 +24,20 @@ function getArticles(req, res, next) {
         })
 }
 
-module.exports = { getArticles, getArticleById }
+function getCommentsByArticleId(req, res, next) {
+
+    const { article_id } = req.params;
+
+    const promises = [selectCommentsByArticleId(article_id), checkArticleIdExists(article_id)]
+
+    Promise.all(promises)
+        .then((resolvedPromises) => {
+            const comments = resolvedPromises[0];
+            res.status(200).send({ comments })
+        })
+        .catch(err => {
+            next(err);
+        }) 
+}
+
+module.exports = { getArticles, getArticleById, getCommentsByArticleId }

--- a/controllers/endpoints-controllers.js
+++ b/controllers/endpoints-controllers.js
@@ -6,7 +6,7 @@ function getEndpoints(req, res, next) {
             .then((endpoints) => {
                 res.status(200).send( {endpoints} )
             })
-
+            .catch((err) => {next(err)})
 }
 
 module.exports = { getEndpoints }

--- a/endpoints.json
+++ b/endpoints.json
@@ -23,5 +23,41 @@
       "article_img_url":
           "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
     }
-  }
+  },
+  "GET /api/articles": {
+      "description": "serves an array of all articles",
+      "queries": ["author", "topic", "sort_by", "order"],
+      "exampleResponse": {
+        "articles": [
+          {
+          "title": "Seafood substitutions are increasing",
+          "topic": "cooking",
+          "author": "weegembump",
+          "body": "Text from the article..",
+          "created_at": "2018-05-30T15:59:13.341Z",
+          "votes": 0,
+          "comment_count": 6
+          }
+        ]
+      }
+    },
+
+    "GET /api/api/articles/:article_id/comments": {
+      "description": "serves an array of all comments with a given article id",
+      "queries": [],
+      "exampleResponse": {
+        "articles": [
+          {
+          "comment_id": 16,
+          "votes": 1,
+          "created_at": "2020-10-11T15:23:00.000Z",
+          "author": "butter_bridge",
+          "body": "This is a bad article name",
+          "article_id": 6
+          }
+        ]
+      }
+    }
+
+
 }

--- a/models/articles-models.js
+++ b/models/articles-models.js
@@ -2,19 +2,19 @@ const db = require("../db/connection");
 
 function selectArticleById(id) {
     return db
-    .query('SELECT * FROM articles WHERE article_id = $1', [id])
-    .then(({rows}) => {
-        if(!rows[0]) {
-            return Promise.reject( {status: 404, msg: "no article found with matching id" })
-        }
-        return rows[0];
-    })
+        .query('SELECT * FROM articles WHERE article_id = $1', [id])
+        .then(({ rows }) => {
+            if (!rows[0]) {
+                return Promise.reject({ status: 404, msg: "no article found with matching id" })
+            }
+            return rows[0];
+        })
 }
 
 function selectArticles() {
     return db
-    .query(
-        `SELECT articles.author, articles.title, articles.article_id, articles.topic, 
+        .query(
+            `SELECT articles.author, articles.title, articles.article_id, articles.topic, 
         articles.created_at, articles.votes, articles.article_img_url, 
         CAST(COALESCE(comment_count_table.comment_count, 0) AS INT) AS comment_count
         FROM articles
@@ -24,10 +24,30 @@ function selectArticles() {
             GROUP BY article_id) AS comment_count_table
         ON articles.article_id = comment_count_table.article_id
         ORDER BY created_at DESC`
-    )
+        )
+        .then(({ rows }) => {
+            return rows;
+        })
+}
+
+function checkArticleIdExists (article_id) {
+    return db
+    .query('SELECT * FROM articles WHERE article_id = $1', [article_id])
     .then(({rows}) => {
-        return rows;
+        if(!rows.length) {
+            return Promise.reject({ status: 404, msg: "no article found with matching id" })
+        }
     })
 }
 
-module.exports = {selectArticles, selectArticleById};
+function selectCommentsByArticleId(article_id) {
+    return db
+        .query(`SELECT * FROM comments 
+        WHERE article_id = $1
+        ORDER BY created_at DESC;`, [article_id])
+        .then(({ rows }) => {
+            return rows;
+        })
+}
+
+module.exports = { selectArticles, selectArticleById, checkArticleIdExists, selectCommentsByArticleId };

--- a/models/endpoints-models.js
+++ b/models/endpoints-models.js
@@ -7,7 +7,6 @@ function selectEndpoints() {
     .then((endpoints) => {
         return JSON.parse(endpoints);
     })
-    .catch((err) => {next(err)})
 }
 
 module.exports = selectEndpoints;


### PR DESCRIPTION
I added an endpoint to return all the comments associated with a given article id, as well as returning a custom error when the id does not exist within the articles table. These comments are sorted by date created, in descending order. 

I also updated the endpoints.json file.